### PR TITLE
fix: prevent CircleHeartIcon from overlapping module title on small screens

### DIFF
--- a/src/styles/Module.css
+++ b/src/styles/Module.css
@@ -351,6 +351,7 @@ body {
   .heart-icon {
     top: -8%;
     left: -2%;
+    width: 5rem;
   }
 
   .plus-btn {


### PR DESCRIPTION
Changed Module.css to enhance responsiveness